### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-13
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-13
     steps:
-      - uses: chartboost/chartboost-ios-adapter-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-ios-adapter-actions/adapter-smoke-test@v2

--- a/Source/BidMachineAdapter.swift
+++ b/Source/BidMachineAdapter.swift
@@ -13,18 +13,26 @@ final class BidMachineAdapter: PartnerAdapter {
     private let SOURCE_ID_KEY = "source_id"
 
     /// The version of the partner SDK.
-    let partnerSDKVersion = BidMachineSdk.sdkVersion
-    
+    var partnerSDKVersion: String {
+        BidMachineAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.2.6.0.0"
-    
+    var adapterVersion: String {
+        BidMachineAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "bidmachine"
-    
+    var partnerID: String {
+        BidMachineAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "BidMachine"
+    var partnerDisplayName: String {
+        BidMachineAdapterConfiguration.partnerDisplayName
+    }
 
     /// Ad storage managed by Chartboost Mediation SDK.
     let storage: PartnerAdapterStorage

--- a/Source/BidMachineAdapterConfiguration.swift
+++ b/Source/BidMachineAdapterConfiguration.swift
@@ -3,11 +3,28 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+import BidMachine
 import Foundation
-
 
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class BidMachineAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        BidMachineSdk.sdkVersion
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.2.6.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "bidmachine"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "BidMachine"
+
     /// Init flag for starting up BidMachine SDK in test mode.
     /// Default value is 'false'.
     @objc public static var testMode: Bool = false

--- a/Source/BidMachineAdapterConfiguration.swift
+++ b/Source/BidMachineAdapterConfiguration.swift
@@ -10,20 +10,20 @@ import Foundation
 @objc public class BidMachineAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         BidMachineSdk.sdkVersion
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.2.6.0.0"
+    @objc public static let adapterVersion = "4.2.6.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "bidmachine"
+    @objc public static let partnerID = "bidmachine"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "BidMachine"
+    @objc public static let partnerDisplayName = "BidMachine"
 
     /// Init flag for starting up BidMachine SDK in test mode.
     /// Default value is 'false'.


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.