### PR TITLE
Update Version to 4.3.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 
 ### 4.3.0.0.0
 - This version of the adapter has been certified with BidMachine 3.0.0.
+- The minimum deployment target compatible with this adapter is now iOS 13.
 
 ### 4.2.7.0.0
 - This version of the adapter has been certified with BidMachine 2.7.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.3.0.0.0
+- This version of the adapter has been certified with BidMachine 3.0.0.
+
 ### 4.2.7.0.0
 - This version of the adapter has been certified with BidMachine 2.7.0.
 

--- a/ChartboostMediationAdapterBidMachine.podspec
+++ b/ChartboostMediationAdapterBidMachine.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
 
   # Minimum supported versions
   spec.swift_version         = '5.1'
-  spec.ios.deployment_target = '12.0'
+  spec.ios.deployment_target = '13.0'
 
   # System frameworks used
   spec.ios.frameworks = ['Foundation', 'UIKit']

--- a/ChartboostMediationAdapterBidMachine.podspec
+++ b/ChartboostMediationAdapterBidMachine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterBidMachine'
-  spec.version     = '4.2.7.0.0'
+  spec.version     = '4.3.0.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-bidmachine'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'BidMachine', '~> 2.7.0'
+  spec.dependency 'BidMachine', '~> 3.0.0'
 
   # Indicates, that if use_frameworks! is specified, the pod should include a static library framework.
   spec.static_framework = true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Chartboost Mediation BidMachine adapter mediates BidMachine via the Chartboo
 | ------ | ------ |
 | Chartboost Mediation SDK | 4.0.0+ |
 | Cocoapods | 1.11.3+ |
-| iOS | 12 |
+| iOS | 13 |
 | Xcode | 14.1+ |
 
 ## Integration

--- a/Source/BidMachineAdapter.swift
+++ b/Source/BidMachineAdapter.swift
@@ -17,7 +17,7 @@ final class BidMachineAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.2.7.0.0"
+    let adapterVersion = "4.3.0.0.0"
     
     /// The partner's unique identifier.
     let partnerIdentifier = "bidmachine"

--- a/Source/BidMachineAdapter.swift
+++ b/Source/BidMachineAdapter.swift
@@ -103,7 +103,9 @@ final class BidMachineAdapter: PartnerAdapter {
                 return
             }
             log(.fetchBidderInfoSucceeded(request))
-            completion(["token": token])
+            // Backend will use a default URL if it receives an empty string in `encoded_key`
+            let encodedKey = BidMachineSdk.shared.extrasValue(by: "chartboost_encoded_url_key") as? String ?? ""
+            completion(["token": token, "encoded_key": encodedKey])
         }
     }
     


### PR DESCRIPTION
Adapter version '4.3.0.0.0', partner version '~> 3.0.0'

One change to the code: we're requesting a key from the BidMachine SDK and sending it to the backend so they can use the corresponding endpoint URL for bidding.